### PR TITLE
Package cape-privacy renamed to cape-dataframes and Pandas compat fixed

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,9 +28,6 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
-    - name: Install cape-privacy
-      run: |
-        pip install cape-privacy --no-deps
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@
 <h3>Dependencies</h3>
 <ol>
   <li> Python (>= 3.7)</li>
-  <li>cape-privacy</li>
+  <li>cape-dataframes</li>
   <li>faker</li>
   <li>pandas</li>
   <li>OpenCV</li>
@@ -106,11 +106,6 @@
 ```
 pip install anonympy
 ```
-<p>Due to conflicting pandas/numpy versions with <a href="https://github.com/capeprivacy/cape-python/issues/112">cape-privacy</a>, it's recommended to install them seperately</p>
-
-```
-pip install cape-privacy==0.3.0 --no-deps 
-```
 
 <h3>Install from source</h3>
 
@@ -121,7 +116,6 @@ git clone https://github.com/ArtLabss/open-data-anonimizer.git
 cd open-data-anonimizer
 pip install -r requirements.txt
 make bootstrap
-pip install cape-privacy==0.3.0 --no-deps 
 ```
 
 <h3>Downloading Repository</h3>

--- a/anonympy/pandas/core_pandas.py
+++ b/anonympy/pandas/core_pandas.py
@@ -3,11 +3,11 @@ import numpy as np
 
 from texttable import Texttable
 
-from cape_privacy.pandas import dtypes
-from cape_privacy.pandas.transformations import NumericPerturbation
-from cape_privacy.pandas.transformations import DatePerturbation
-from cape_privacy.pandas.transformations import NumericRounding
-from cape_privacy.pandas.transformations import Tokenizer
+from cape_dataframes.pandas import dtypes
+from cape_dataframes.pandas.transformations import NumericPerturbation
+from cape_dataframes.pandas.transformations import DatePerturbation
+from cape_dataframes.pandas.transformations import NumericRounding
+from cape_dataframes.pandas.transformations import Tokenizer
 
 from faker import Faker
 from anonympy.pandas import utils_pandas as _utils
@@ -589,7 +589,7 @@ class dfAnonymizer(object):
                       inplace=True):
         '''
         Add uniform random noise
-        Based on cape-privacy's NumericPerturbation function.
+        Based on cape-dataframes's NumericPerturbation function.
 
         Mask a numeric pandas Series/DataFrame by adding uniform random
         noise to each value. The amount of noise is drawn from
@@ -690,7 +690,7 @@ class dfAnonymizer(object):
                        inplace=True):
         '''
         Add uniform random noise to a Pandas series of timestamps
-        Based on cape-privacy's DatePerturbation function
+        Based on cape-dataframes's DatePerturbation function
 
         Parameters
         ----------
@@ -784,7 +784,7 @@ class dfAnonymizer(object):
                          inplace=True):
         '''
         Round each value in the Pandas Series to the given number
-        Based on cape-privacy's NumericRounding.
+        Based on cape-dataframes's NumericRounding.
 
         Parameters
         ----------

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
                     'texttable', 'setuptools', 'numpy', 'pandas', 'validators',
                     'pycryptodome', 'requests', 'pyyaml', 'rfc3339',
                     'pytesseract', 'pypdf', 'poppler-utils', 'pdf2image',
-                    'transformers'],
+                    'transformers', 'cape-dataframes>=0.3.1'],
 
   python_requires='>=3.6',
   url='https://github.com/ArtLabss/open-data-anonimizer',


### PR DESCRIPTION
Since https://github.com/capeprivacy/cape-dataframes/issues/112 has been fixed, then we can proceed to rename the depencency and resolve the pip install conflicts.